### PR TITLE
Add CustomerDomain single table and loader

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: config.yaml
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:34 UTC 2025
 # Description: Configuration for AWS resources.
 
 aws:
@@ -12,4 +12,4 @@ aws:
     timeout: 30
     memory_size: 256
 dynamodb:
-  table_name: ExampleTable
+  table_name: CustomerDomain

--- a/data/test_customers.json
+++ b/data/test_customers.json
@@ -1,0 +1,18 @@
+[
+  {
+    "customerId": "11111111-1111-1111-1111-111111111111",
+    "name": { "first": "Alice", "last": "Smith" },
+    "primaryEmail": "alice@example.com",
+    "status": "ACTIVE",
+    "createdAt": "2025-06-05T14:32:11Z",
+    "updatedAt": "2025-06-05T14:32:11Z"
+  },
+  {
+    "customerId": "22222222-2222-2222-2222-222222222222",
+    "name": { "first": "Bob", "last": "Jones" },
+    "primaryEmail": "bob@example.com",
+    "status": "ACTIVE",
+    "createdAt": "2025-06-05T15:00:00Z",
+    "updatedAt": "2025-06-05T15:00:00Z"
+  }
+]

--- a/e2e/test_requests.http
+++ b/e2e/test_requests.http
@@ -1,22 +1,25 @@
 # App: AWS Customer CRUD
 # Package: e2e
 # File: test_requests.http
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Example HTTP requests for integration testing.
 
-### Create Item
-POST https://example.com/items
+### Create Customer
+POST https://example.com/customers
 Content-Type: application/json
 Authorization: Bearer <token>
 
 {
-  "id": "1",
-  "name": "Item1",
-  "description": "A test item"
+  "customerId": "1",
+  "name": {"first": "Alice", "last": "Smith"},
+  "primaryEmail": "alice@example.com",
+  "createdAt": "2025-06-05T00:00:00Z",
+  "updatedAt": "2025-06-05T00:00:00Z",
+  "status": "ACTIVE"
 }
 
-### Get Item
-GET https://example.com/items/1
+### Get Customer
+GET https://example.com/customers/1
 Authorization: Bearer <token>

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -1,22 +1,28 @@
 # App: AWS Customer CRUD
 # Package: iac.terraform
 # File: main.tf
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Terraform configuration for CRUD API.
 
 provider "aws" {
   region = var.aws_region
 }
 
-resource "aws_dynamodb_table" "example_table" {
+resource "aws_dynamodb_table" "customer_domain" {
   name         = var.dynamodb_table_name
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "id"
+  hash_key     = "pk"
+  range_key    = "sk"
 
   attribute {
-    name = "id"
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
     type = "S"
   }
 }
@@ -61,7 +67,7 @@ resource "aws_api_gateway_rest_api" "crud_api" {
 resource "aws_api_gateway_resource" "items_resource" {
   rest_api_id = aws_api_gateway_rest_api.crud_api.id
   parent_id   = aws_api_gateway_rest_api.crud_api.root_resource_id
-  path_part   = "items"
+  path_part   = "customers"
 }
 
 resource "aws_api_gateway_method" "items_method" {

--- a/iac/terraform/output.tf
+++ b/iac/terraform/output.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac.terraform
 # File: output.tf
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Terraform outputs for AWS resources.
 
 output "api_url" {
@@ -17,6 +17,6 @@ output "lambda_function_arn" {
 }
 
 output "dynamodb_table_name" {
-  value       = aws_dynamodb_table.example_table.name
+  value       = aws_dynamodb_table.customer_domain.name
   description = "Name of the DynamoDB table"
 }

--- a/iac/terraform/variables.tf
+++ b/iac/terraform/variables.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac.terraform
 # File: variables.tf
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Terraform variables for AWS resources.
 
 variable "aws_region" {
@@ -15,5 +15,5 @@ variable "aws_region" {
 variable "dynamodb_table_name" {
   description = "Name of the DynamoDB table"
   type        = string
-  default     = "ExampleTable"
+  default     = "CustomerDomain"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: pyproject.toml
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:34 UTC 2025
 # Description: Project configuration.
 
 [tool.poetry]
 name = "aws-customer-crud"
-version = "0.0.1"
+version = "0.0.2"
 description = "AWS Lambda CRUD application"
 authors = ["Bobwares <bobwares@example.com>"]
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,14 +1,14 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: app.py
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: AWS Lambda handler for CRUD operations on DynamoDB.
 
 import json
 from typing import Any, Dict
-from .models import Item
+from .models import Customer
 from .utils import get_dynamodb_client, validate_jwt
 
 
@@ -23,42 +23,46 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             "statusCode": 401,
             "body": json.dumps({"message": "Unauthorized"})
         }
-    if http_method == "POST" and path == "/items":
+    table = "CustomerDomain"
+
+    if http_method == "POST" and path == "/customers":
         body = json.loads(event["body"])
-        item = Item(**body)
-        client.put_item(TableName="ExampleTable", Item=item.to_dynamodb())
+        item = Customer(**body)
+        client.put_item(TableName=table, Item=item.to_dynamodb())
         return {
             "statusCode": 201,
-            "body": json.dumps({"message": "Item created"})
+            "body": json.dumps({"message": "Customer created"})
         }
-    if http_method == "GET" and path.startswith("/items/"):
+    if http_method == "GET" and path.startswith("/customers/"):
         item_id = path.split("/")[-1]
-        response = client.get_item(TableName="ExampleTable", Key={"id": {"S": item_id}})
+        pk = f"CUSTOMER#{item_id}"
+        response = client.get_item(TableName=table, Key={"pk": {"S": pk}, "sk": {"S": "METADATA"}})
         item = response.get("Item")
         if item:
             return {
                 "statusCode": 200,
-                "body": json.dumps(Item.from_dynamodb(item).dict())
+                "body": json.dumps(Customer.from_dynamodb(item).dict())
             }
         return {
             "statusCode": 404,
-            "body": json.dumps({"message": "Item not found"})
+            "body": json.dumps({"message": "Customer not found"})
         }
-    if http_method == "PUT" and path.startswith("/items/"):
+    if http_method == "PUT" and path.startswith("/customers/"):
         item_id = path.split("/")[-1]
         body = json.loads(event["body"])
-        item = Item(id=item_id, **body)
-        client.put_item(TableName="ExampleTable", Item=item.to_dynamodb())
+        item = Customer(customerId=item_id, **body)
+        client.put_item(TableName=table, Item=item.to_dynamodb())
         return {
             "statusCode": 200,
-            "body": json.dumps({"message": "Item updated"})
+            "body": json.dumps({"message": "Customer updated"})
         }
-    if http_method == "DELETE" and path.startswith("/items/"):
+    if http_method == "DELETE" and path.startswith("/customers/"):
         item_id = path.split("/")[-1]
-        client.delete_item(TableName="ExampleTable", Key={"id": {"S": item_id}})
+        pk = f"CUSTOMER#{item_id}"
+        client.delete_item(TableName=table, Key={"pk": {"S": pk}, "sk": {"S": "METADATA"}})
         return {
             "statusCode": 200,
-            "body": json.dumps({"message": "Item deleted"})
+            "body": json.dumps({"message": "Customer deleted"})
         }
     return {
         "statusCode": 400,

--- a/src/batch_loader.py
+++ b/src/batch_loader.py
@@ -1,0 +1,40 @@
+# App: AWS Customer CRUD
+# Package: src
+# File: batch_loader.py
+# Version: 0.0.2
+# Author: Bobwares
+# Date: Thu Jun 05 17:10:34 UTC 2025
+# Description: Batch load customer data into DynamoDB table.
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import boto3
+
+from .utils import get_dynamodb_client
+
+
+def load_customers(file_path: str, table_name: str) -> None:
+    """Load customers from JSON file into DynamoDB."""
+    client = get_dynamodb_client()
+    items: List[Dict[str, Any]] = json.loads(Path(file_path).read_text())
+    with client.batch_writer(TableName=table_name) as writer:  # type: ignore
+        for item in items:
+            pk = f"CUSTOMER#{item['customerId']}"
+            writer.put_item(Item={
+                'pk': {'S': pk},
+                'sk': {'S': 'METADATA'},
+                'data': {'S': json.dumps(item)}
+            })
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Batch load customer data")
+    parser.add_argument("file", help="Path to JSON data file")
+    parser.add_argument("--table", default="CustomerDomain", help="DynamoDB table name")
+    args = parser.parse_args()
+
+    load_customers(args.file, args.table)

--- a/src/models.py
+++ b/src/models.py
@@ -1,35 +1,66 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: models.py
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
-# Description: Data models for domain entities.
+# Date: Thu Jun 05 17:10:52 UTC 2025
+# Description: Customer domain models for DynamoDB single table design.
 
-from pydantic import BaseModel, Field
-from typing import Any, Dict
+from datetime import datetime, date
+from typing import Any, Dict, Optional, List
+from pydantic import BaseModel, Field, EmailStr
 
 
-class Item(BaseModel):
-    """Item model for DynamoDB storage."""
+class CustomerName(BaseModel):
+    first: str
+    last: str
+    middle: Optional[str] = None
+    prefix: Optional[str] = None
+    suffix: Optional[str] = None
 
-    id: str = Field(..., description="Unique identifier for the item")
-    name: str = Field(..., description="Name of the item")
-    description: str = Field(..., description="Description of the item")
+
+class PhoneNumber(BaseModel):
+    label: str
+    number: str
+
+
+class Address(BaseModel):
+    addressType: str
+    line1: str
+    line2: Optional[str] = None
+    city: str
+    state: Optional[str] = None
+    postalCode: Optional[str] = None
+    country: str
+
+
+class Customer(BaseModel):
+    customerId: str
+    name: CustomerName
+    primaryEmail: EmailStr
+    createdAt: datetime
+    updatedAt: datetime
+    status: str
+    externalIds: Optional[Dict[str, str]] = None
+    secondaryEmails: Optional[List[EmailStr]] = None
+    phoneNumbers: Optional[List[PhoneNumber]] = None
+    addresses: Optional[List[Address]] = None
+    dateOfBirth: Optional[date] = None
+    customAttributes: Optional[Dict[str, Any]] = None
+    etag: Optional[str] = None
+
+    class Config:
+        validate_assignment = True
 
     def to_dynamodb(self) -> Dict[str, Any]:
-        """Convert the Item instance to a DynamoDB compatible format."""
+        pk = f"CUSTOMER#{self.customerId}"
         return {
-            "id": {"S": self.id},
-            "name": {"S": self.name},
-            "description": {"S": self.description}
+            'pk': {'S': pk},
+            'sk': {'S': 'METADATA'},
+            'data': {'S': self.json(by_alias=True)}
         }
 
     @classmethod
-    def from_dynamodb(cls, item: Dict[str, Any]) -> "Item":
-        """Create an Item instance from a DynamoDB item."""
-        return cls(
-            id=item["id"]["S"],
-            name=item["name"]["S"],
-            description=item["description"]["S"]
-        )
+    def from_dynamodb(cls, item: Dict[str, Any]) -> "Customer":
+        data = item['data']['S']
+        return cls.parse_raw(data)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: utils.py
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Utility functions for AWS interactions.
 
 import boto3

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_app.py
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Unit tests for app module.
 
 import json
@@ -13,35 +13,35 @@ from src.app import lambda_handler
 
 @patch('src.app.get_dynamodb_client')
 @patch('src.app.validate_jwt')
-def test_lambda_handler_create_item(mock_validate_jwt, mock_get_dynamodb_client):
-    """Test creating an item."""
+def test_lambda_handler_create_customer(mock_validate_jwt, mock_get_dynamodb_client):
+    """Test creating a customer."""
     mock_validate_jwt.return_value = True
     mock_client = mock_get_dynamodb_client.return_value
     event = {
         'httpMethod': 'POST',
-        'path': '/items',
+        'path': '/customers',
         'headers': {'Authorization': 'Bearer validtoken'},
-        'body': json.dumps({'id': '1', 'name': 'Item1', 'description': 'A test item'})
+        'body': json.dumps({'customerId': '1', 'name': {'first': 'Item1', 'last': 'Test'}, 'primaryEmail': 't@example.com', 'createdAt': '2025-06-05T00:00:00Z', 'updatedAt': '2025-06-05T00:00:00Z', 'status': 'ACTIVE'})
     }
     response = lambda_handler(event, None)
     assert response['statusCode'] == 201
-    assert json.loads(response['body'])['message'] == 'Item created'
+    assert json.loads(response['body'])['message'] == 'Customer created'
     mock_client.put_item.assert_called_once()
 
 
 @patch('src.app.get_dynamodb_client')
 @patch('src.app.validate_jwt')
-def test_lambda_handler_get_item_not_found(mock_validate_jwt, mock_get_dynamodb_client):
-    """Test retrieving a non-existent item."""
+def test_lambda_handler_get_customer_not_found(mock_validate_jwt, mock_get_dynamodb_client):
+    """Test retrieving a non-existent customer."""
     mock_validate_jwt.return_value = True
     mock_client = mock_get_dynamodb_client.return_value
     mock_client.get_item.return_value = {}
     event = {
         'httpMethod': 'GET',
-        'path': '/items/999',
+        'path': '/customers/999',
         'headers': {'Authorization': 'Bearer validtoken'},
         'body': None
     }
     response = lambda_handler(event, None)
     assert response['statusCode'] == 404
-    assert json.loads(response['body'])['message'] == 'Item not found'
+    assert json.loads(response['body'])['message'] == 'Customer not found'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,17 +1,24 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_models.py
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Thu Jun 05 17:10:52 UTC 2025
 # Description: Unit tests for models module.
 
-from src.models import Item
+from src.models import Customer, CustomerName
 
 
-def test_item_serialization():
-    """Test serialization and deserialization of Item."""
-    item = Item(id="1", name="Test Item", description="This is a test.")
-    dynamodb_item = item.to_dynamodb()
-    new_item = Item.from_dynamodb(dynamodb_item)
-    assert new_item == item
+def test_customer_serialization():
+    """Test serialization and deserialization of Customer."""
+    customer = Customer(
+        customerId="1",
+        name=CustomerName(first="Test", last="User"),
+        primaryEmail="test@example.com",
+        createdAt="2025-06-05T00:00:00Z",
+        updatedAt="2025-06-05T00:00:00Z",
+        status="ACTIVE"
+    )
+    dynamodb_item = customer.to_dynamodb()
+    new_customer = Customer.from_dynamodb(dynamodb_item)
+    assert new_customer == customer

--- a/version.md
+++ b/version.md
@@ -2,3 +2,8 @@
 
 ## 0.0.1 - Thu Jun 5 14:41:42 UTC 2025
 - Initial project structure with Lambda CRUD application, tests, Terraform, and configuration files.
+
+## 0.0.2 - Thu Jun 05 17:12:05 UTC 2025
+- Added single table DynamoDB design with CustomerDomain table.
+- Updated application code and tests for Customer model.
+- Added batch loader script and sample dataset.


### PR DESCRIPTION
## Summary
- introduce new CustomerDomain DynamoDB single table
- update application code and models for customers
- add batch loader utility and sample data
- adjust Terraform and tests for new table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cf28e940832da40635edbdcf564c