### PR TITLE
Integrate jsonschema validation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: config.yaml
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:34 UTC 2025
+# Date: Thu Jun 05 17:57:23 UTC 2025
 # Description: Configuration for AWS resources.
 
 aws:

--- a/data/test_customers.json
+++ b/data/test_customers.json
@@ -1,16 +1,38 @@
 [
   {
     "customerId": "11111111-1111-1111-1111-111111111111",
-    "name": { "first": "Alice", "last": "Smith" },
+    "name": {"first": "Alice", "last": "Smith"},
     "primaryEmail": "alice@example.com",
+    "phoneNumbers": [{"label": "mobile", "number": "+14155550001"}],
+    "addresses": [
+      {
+        "addressType": "home",
+        "line1": "123 Main St",
+        "city": "Austin",
+        "state": "TX",
+        "postalCode": "78701",
+        "country": "US"
+      }
+    ],
     "status": "ACTIVE",
     "createdAt": "2025-06-05T14:32:11Z",
     "updatedAt": "2025-06-05T14:32:11Z"
   },
   {
     "customerId": "22222222-2222-2222-2222-222222222222",
-    "name": { "first": "Bob", "last": "Jones" },
+    "name": {"first": "Bob", "last": "Jones"},
     "primaryEmail": "bob@example.com",
+    "phoneNumbers": [{"label": "mobile", "number": "+14155550002"}],
+    "addresses": [
+      {
+        "addressType": "home",
+        "line1": "1 Second St",
+        "city": "Austin",
+        "state": "TX",
+        "postalCode": "78701",
+        "country": "US"
+      }
+    ],
     "status": "ACTIVE",
     "createdAt": "2025-06-05T15:00:00Z",
     "updatedAt": "2025-06-05T15:00:00Z"

--- a/e2e/test_requests.http
+++ b/e2e/test_requests.http
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: e2e
 # File: test_requests.http
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:52 UTC 2025
+# Date: Thu Jun 05 17:57:23 UTC 2025
 # Description: Example HTTP requests for integration testing.
 
 ### Create Customer
@@ -12,14 +12,15 @@ Content-Type: application/json
 Authorization: Bearer <token>
 
 {
-  "customerId": "1",
+  "customerId": "55555555-5555-5555-5555-555555555555",
   "name": {"first": "Alice", "last": "Smith"},
   "primaryEmail": "alice@example.com",
+  "phoneNumbers": [{"label": "mobile", "number": "+14155550005"}],
   "createdAt": "2025-06-05T00:00:00Z",
   "updatedAt": "2025-06-05T00:00:00Z",
   "status": "ACTIVE"
 }
 
 ### Get Customer
-GET https://example.com/customers/1
+GET https://example.com/customers/55555555-5555-5555-5555-555555555555
 Authorization: Bearer <token>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: pyproject.toml
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:34 UTC 2025
+# Date: Thu Jun 05 17:57:23 UTC 2025
 # Description: Project configuration.
 
 [tool.poetry]
 name = "aws-customer-crud"
-version = "0.0.2"
+version = "0.0.3"
 description = "AWS Lambda CRUD application"
 authors = ["Bobwares <bobwares@example.com>"]
 
@@ -18,6 +18,7 @@ boto3 = ">=1.26.0"
 pydantic = ">=1.10.2"
 aws-lambda-powertools = "^1.27.0"
 python-jose = ">=3.3.0"
+jsonschema = ">=4.18.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,15 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: app.py
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:52 UTC 2025
+# Date: Thu Jun 05 17:57:23 UTC 2025
 # Description: AWS Lambda handler for CRUD operations on DynamoDB.
 
 import json
 from typing import Any, Dict
 from .models import Customer
-from .utils import get_dynamodb_client, validate_jwt
+from .utils import get_dynamodb_client, validate_jwt, validate_customer_schema
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -27,6 +27,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     if http_method == "POST" and path == "/customers":
         body = json.loads(event["body"])
+        validate_customer_schema(body)
         item = Customer(**body)
         client.put_item(TableName=table, Item=item.to_dynamodb())
         return {
@@ -50,6 +51,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     if http_method == "PUT" and path.startswith("/customers/"):
         item_id = path.split("/")[-1]
         body = json.loads(event["body"])
+        validate_customer_schema(body | {"customerId": item_id})
         item = Customer(customerId=item_id, **body)
         client.put_item(TableName=table, Item=item.to_dynamodb())
         return {

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,13 +1,23 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: utils.py
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:52 UTC 2025
+# Date: Thu Jun 05 17:57:07 UTC 2025
 # Description: Utility functions for AWS interactions.
+
+import json
+from pathlib import Path
+from typing import Any, Dict
 
 import boto3
 from jose import JWTError, jwt
+from jsonschema import Draft202012Validator
+
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema/customer_domain.json"
+CUSTOMER_SCHEMA = json.loads(SCHEMA_PATH.read_text())
+CUSTOMER_VALIDATOR = Draft202012Validator(CUSTOMER_SCHEMA)
 
 
 def get_dynamodb_client():
@@ -22,3 +32,8 @@ def validate_jwt(token: str) -> bool:
         return True
     except JWTError:
         return False
+
+
+def validate_customer_schema(data: Dict[str, Any]) -> None:
+    """Validate customer payload against JSON schema."""
+    CUSTOMER_VALIDATOR.validate(data)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_app.py
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:52 UTC 2025
+# Date: Thu Jun 05 17:57:23 UTC 2025
 # Description: Unit tests for app module.
 
 import json
@@ -21,7 +21,15 @@ def test_lambda_handler_create_customer(mock_validate_jwt, mock_get_dynamodb_cli
         'httpMethod': 'POST',
         'path': '/customers',
         'headers': {'Authorization': 'Bearer validtoken'},
-        'body': json.dumps({'customerId': '1', 'name': {'first': 'Item1', 'last': 'Test'}, 'primaryEmail': 't@example.com', 'createdAt': '2025-06-05T00:00:00Z', 'updatedAt': '2025-06-05T00:00:00Z', 'status': 'ACTIVE'})
+        'body': json.dumps({
+            'customerId': '33333333-3333-3333-3333-333333333333',
+            'name': {'first': 'Item1', 'last': 'Test'},
+            'primaryEmail': 't@example.com',
+            'phoneNumbers': [{'label': 'mobile', 'number': '+14155550003'}],
+            'status': 'ACTIVE',
+            'createdAt': '2025-06-05T00:00:00Z',
+            'updatedAt': '2025-06-05T00:00:00Z'
+        })
     }
     response = lambda_handler(event, None)
     assert response['statusCode'] == 201

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_models.py
-# Version: 0.0.2
+# Version: 0.0.3
 # Author: Bobwares
-# Date: Thu Jun 05 17:10:52 UTC 2025
+# Date: Thu Jun 05 17:57:23 UTC 2025
 # Description: Unit tests for models module.
 
 from src.models import Customer, CustomerName
@@ -12,9 +12,10 @@ from src.models import Customer, CustomerName
 def test_customer_serialization():
     """Test serialization and deserialization of Customer."""
     customer = Customer(
-        customerId="1",
+        customerId="44444444-4444-4444-4444-444444444444",
         name=CustomerName(first="Test", last="User"),
         primaryEmail="test@example.com",
+        phoneNumbers=[{"label": "mobile", "number": "+14155550004"}],
         createdAt="2025-06-05T00:00:00Z",
         updatedAt="2025-06-05T00:00:00Z",
         status="ACTIVE"

--- a/version.md
+++ b/version.md
@@ -7,3 +7,8 @@
 - Added single table DynamoDB design with CustomerDomain table.
 - Updated application code and tests for Customer model.
 - Added batch loader script and sample dataset.
+
+## 0.0.3 - Thu Jun 05 17:58:25 UTC 2025
+- Integrated jsonschema validation for customer payloads.
+- Updated test data to conform to customer_domain schema.
+- Updated application and configuration versions.


### PR DESCRIPTION
## Summary
- add jsonschema validation helper
- validate POST and PUT requests against customer schema
- update sample data and tests with UUIDs and phone/address info
- bump version numbers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841da2495b8832d83851678c4cb5ff5