### PR TITLE
Add modular Terraform with registry modules

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,0 +1,102 @@
+# App: AWS Customer CRUD
+# Package: iac
+# File: main.tf
+# Version: 0.0.5
+# Author: Bobwares
+# Date: Thu Jun 05 21:17:09 UTC 2025
+# Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
+#
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.94"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "cloud"
+  region = "us-east-1"
+}
+
+########################
+# Lambda Function (Registry Module)
+########################
+module "lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "7.20.2"
+
+  function_name = "${var.env}-APIGatewayEventHandler-${var.function_name}"
+  handler       = "handler.processAPIGatewayEvent"
+  runtime       = "nodejs22.x"
+  source_path   = "../code/.build"
+  publish       = true
+
+  environment_variables = {
+    LOG_GROUP_NAME = "${var.env}-APIGatewayEventHandler-${var.function_name}"
+  }
+
+  logging_log_group             = "${var.env}-APIGatewayEventHandler-${var.function_name}"
+  logging_log_format            = "JSON"
+  logging_system_log_level      = "INFO"
+  logging_application_log_level = "INFO"
+
+  tags = {
+    Project = "aws-step-functions"
+  }
+}
+
+########################
+# HTTP API Gateway (Registry Module - Quick Create)
+########################
+module "http_api" {
+  source  = "terraform-aws-modules/apigateway-v2/aws"
+  version = "5.2.1"
+
+  name          = "${var.env}-api-${var.function_name}"
+  description   = "HTTP API for ${var.function_name}"
+  protocol_type = "HTTP"
+
+  cors_configuration = {
+    allow_headers = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]
+    allow_methods = ["*"]
+    allow_origins = ["*"]
+  }
+
+  integrations = {
+    "ANY /${var.resource}" = {
+      lambda_arn = module.lambda.lambda_function_arn
+    }
+  }
+
+  default_stage_access_log_destination_arn = module.lambda.lambda_cloudwatch_log_group_arn
+  default_stage_access_log_format          = jsonencode({ requestId = "$context.requestId" })
+
+  tags = {
+    Project = "aws-step-functions"
+  }
+}
+
+########################
+# Lambda Permission for API Gateway
+########################
+resource "aws_lambda_permission" "allow_apigateway" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${module.http_api.apigatewayv2_api_execution_arn}/*/*"
+}
+
+########################
+# Variable for source_code_hash
+########################
+variable "source_code_hash" {
+  description = "Hash of the source code package"
+  type        = string
+  default     = null
+}

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,0 +1,18 @@
+# App: AWS Customer CRUD
+# Package: iac
+# File: outputs.tf
+# Version: 0.0.5
+# Author: Bobwares
+# Date: Thu Jun 05 21:17:09 UTC 2025
+# Description: Outputs for Lambda and HTTP API resources.
+#
+
+output "lambda_function_name" {
+  value       = module.lambda.lambda_function_name
+  description = "Deployed Lambda function name"
+}
+
+output "api_endpoint" {
+  value       = aws_apigatewayv2_api.http_api.api_endpoint
+  description = "API Gateway endpoint URL"
+}

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -1,0 +1,26 @@
+# App: AWS Customer CRUD
+# Package: iac
+# File: variables.tf
+# Version: 0.0.5
+# Author: Bobwares
+# Date: Thu Jun 05 21:17:09 UTC 2025
+# Description: Input variables for Lambda and API Gateway configuration.
+#
+
+variable "env" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "function_name" {
+  description = "Logical name of the Lambda function"
+  type        = string
+  default     = "EventProcessor"
+}
+
+variable "resource" {
+  description = "API Gateway resource path (e.g., process)"
+  type        = string
+  default     = "process"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: pyproject.toml
-# Version: 0.0.4
+# Version: 0.0.5
 # Author: Bobwares
-# Date: Thu Jun 05 20:20:35 UTC 2025
+# Date: Thu Jun 05 21:17:09 UTC 2025
 # Description: Project configuration.
 
 [tool.poetry]
 name = "aws-customer-crud"
-version = "0.0.4"
+version = "0.0.5"
 description = "AWS Lambda CRUD application"
 authors = ["Bobwares <bobwares@example.com>"]
 

--- a/version.md
+++ b/version.md
@@ -17,3 +17,7 @@
 - Added AWS Step Functions state machine for input validation and CRUD operations.
 - Introduced application logging.
 - Bumped project version to 0.0.4 and updated tests.
+
+## 0.0.5 - Thu Jun 05 21:17:49 UTC 2025
+- Added new Terraform configuration using registry modules for Lambda and HTTP API Gateway.
+- Bumped project version to 0.0.5.


### PR DESCRIPTION
## Summary
- add Terraform configuration using registry modules for Lambda and API Gateway
- provide new outputs and variables files
- bump project version to 0.0.5

## Testing
- `pytest -q`
- `terraform -chdir=iac init -backend=false` *(fails: failed to request discovery document)*
- `terraform -chdir=iac validate` *(fails: modules not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684207ec6a54832d9533f6e9728b263e