### PR TITLE
Fix HTTP API execution ARN reference

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.6
+# Version: 0.0.7
 # Author: Bobwares
-# Date: Thu Jun 05 21:45:11 UTC 2025
+# Date: Thu Jun 05 22:00:00 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -93,7 +93,7 @@ resource "aws_lambda_permission" "allow_apigateway" {
   action        = "lambda:InvokeFunction"
   function_name = module.lambda.lambda_function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${module.http_api.apigatewayv2_api_execution_arn}/*/*"
+  source_arn    = "${module.http_api.api_execution_arn}/*/*"
 }
 
 ########################

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: outputs.tf
-# Version: 0.0.6
+# Version: 0.0.7
 # Author: Bobwares
-# Date: Thu Jun 05 21:45:11 UTC 2025
+# Date: Thu Jun 05 22:00:00 UTC 2025
 # Description: Outputs for Lambda and HTTP API resources.
 #
 

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: variables.tf
-# Version: 0.0.6
+# Version: 0.0.7
 # Author: Bobwares
-# Date: Thu Jun 05 21:45:11 UTC 2025
+# Date: Thu Jun 05 22:00:00 UTC 2025
 
 # Description: Input variables for Lambda and API Gateway configuration.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: pyproject.toml
-# Version: 0.0.6
+# Version: 0.0.7
 # Author: Bobwares
-# Date: Thu Jun 05 21:45:11 UTC 2025
+# Date: Thu Jun 05 22:00:00 UTC 2025
 # Description: Project configuration.
 
 [tool.poetry]
 name = "aws-customer-crud"
-version = "0.0.6"
+version = "0.0.7"
 
 description = "AWS Lambda CRUD application"
 authors = ["Bobwares <bobwares@example.com>"]

--- a/version.md
+++ b/version.md
@@ -28,3 +28,7 @@
 - Updated outputs to use module output
 - Bumped project version to 0.0.6
 
+## 0.0.7 - Thu Jun 05 22:00:00 UTC 2025
+- Fixed http_api execution ARN reference for Lambda permission
+- Bumped project version to 0.0.7
+


### PR DESCRIPTION
## Summary
- correct API Gateway execution ARN output in Terraform
- bump version numbers to 0.0.7

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421907e1f4832d86c32a97b6991749