### PR TITLE
Update build workflow and Terraform module config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# App: AWS Customer CRUD
+# Package: project_root
+# File: Makefile
+# Version: 0.0.8
+# Author: Bobwares
+# Date: Fri Jun 06 02:53:56 UTC 2025
+# Description: Convenience targets for build, test, and deployment.
+#
+
+.PHONY: build test plan deploy
+
+build:
+	pip install -r requirements.txt
+
+test:
+	pytest -q
+
+plan:
+	cd iac && terraform init && terraform plan
+
+deploy:
+	cd iac && terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ an AWS Step Functions workflow. The state machine validates input, determines
 the requested operation, and invokes the Lambda function to perform the CRUD
 action. Logging is enabled throughout the application for operational
 visibility.
+
+## Development
+
+The `Makefile` provides a few convenience targets:
+
+- `make build` – install Python dependencies
+- `make test` – run unit tests
+- `make plan` – execute `terraform plan` from the `iac` directory
+- `make deploy` – deploy infrastructure with Terraform

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.7
+# Version: 0.0.8
 # Author: Bobwares
-# Date: Thu Jun 05 22:00:00 UTC 2025
+# Date: Fri Jun 06 02:53:56 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -31,9 +31,9 @@ module "lambda" {
   version = "7.20.2"
 
   function_name = "${var.env}-APIGatewayEventHandler-${var.function_name}"
-  handler       = "handler.processAPIGatewayEvent"
-  runtime       = "nodejs22.x"
-  source_path   = "../code/.build"
+  handler       = "app.lambda_handler"
+  runtime       = "python3.11"
+  source_path   = "../src"
   publish       = true
 
   environment_variables = {
@@ -60,6 +60,8 @@ module "http_api" {
   name          = "${var.env}-api-${var.function_name}"
   description   = "HTTP API for ${var.function_name}"
   protocol_type = "HTTP"
+  disable_execute_api_endpoint = false
+  create_domain_name           = false
 
   cors_configuration = {
     allow_headers = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: pyproject.toml
-# Version: 0.0.7
+# Version: 0.0.8
 # Author: Bobwares
-# Date: Thu Jun 05 22:00:00 UTC 2025
+# Date: Fri Jun 06 02:53:56 UTC 2025
 # Description: Project configuration.
 
 [tool.poetry]
 name = "aws-customer-crud"
-version = "0.0.7"
+version = "0.0.8"
 
 description = "AWS Lambda CRUD application"
 authors = ["Bobwares <bobwares@example.com>"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# App: AWS Customer CRUD
+# Package: project_root
+# File: requirements.txt
+# Version: 0.0.8
+# Author: Bobwares
+# Date: Fri Jun  6 02:53:51 UTC 2025
+# Description: Python dependencies for Lambda function.
+#
+
+boto3>=1.26.0
+pydantic[email]>=1.10.2
+aws-lambda-powertools>=1.27.0
+python-jose>=3.3.0
+jsonschema>=4.18.0

--- a/version.md
+++ b/version.md
@@ -32,3 +32,9 @@
 - Fixed http_api execution ARN reference for Lambda permission
 - Bumped project version to 0.0.7
 
+
+## 0.0.8 - Fri Jun 06 02:53:56 UTC 2025
+- Updated Terraform lambda runtime and API module defaults
+- Added Makefile with build/test/deploy commands
+- Documented dependencies in requirements.txt
+- Bumped project version to 0.0.8


### PR DESCRIPTION
## Summary
- update Terraform lambda configuration
- disable custom domain in API Gateway module
- add Makefile with build/test/deploy targets
- document steps in README and requirements file
- bump version to 0.0.8

## Testing
- `pytest -q`
- `terraform -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842579d492c832d87eb6617ccf49a30