### PR TITLE
Add setup script and codex configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ action. Logging is enabled throughout the application for operational
 visibility.
 
 ## Development
+Run `setup.sh` to install Terraform and Python dependencies. The Codex project automatically executes this script when the workspace is created.
 
 The `Makefile` provides a few convenience targets:
 

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,11 @@
+# App: AWS Customer CRUD
+# Package: project_root
+# File: codex.yaml
+# Version: 0.0.10
+# Author: Bobwares
+# Date: Fri Jun 06 16:06:00 UTC 2025
+# Description: Codex configuration to run setup.sh on workspace creation.
+#
+
+on_create:
+  - ./setup.sh

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.8
+# Version: 0.0.9
 # Author: Bobwares
-# Date: Fri Jun 06 02:53:56 UTC 2025
+# Date: Fri Jun 06 15:56:09 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -30,17 +30,17 @@ module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "7.20.2"
 
-  function_name = "${var.env}-APIGatewayEventHandler-${var.function_name}"
+  function_name = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}"
   handler       = "app.lambda_handler"
   runtime       = "python3.11"
   source_path   = "../src"
   publish       = true
 
   environment_variables = {
-    LOG_GROUP_NAME = "${var.env}-APIGatewayEventHandler-${var.function_name}"
+    LOG_GROUP_NAME = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}"
   }
 
-  logging_log_group             = "${var.env}-APIGatewayEventHandler-${var.function_name}"
+  logging_log_group             = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}"
   logging_log_format            = "JSON"
   logging_system_log_level      = "INFO"
   logging_application_log_level = "INFO"
@@ -57,7 +57,7 @@ module "http_api" {
   source  = "terraform-aws-modules/apigateway-v2/aws"
   version = "5.2.1"
 
-  name          = "${var.env}-api-${var.function_name}"
+  name          = "${var.app_name}-${var.env}-api-${var.function_name}"
   description   = "HTTP API for ${var.function_name}"
   protocol_type = "HTTP"
   disable_execute_api_endpoint = false

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: variables.tf
-# Version: 0.0.7
+# Version: 0.0.9
 # Author: Bobwares
-# Date: Thu Jun 05 22:00:00 UTC 2025
+# Date: Fri Jun 06 15:56:09 UTC 2025
 
 # Description: Input variables for Lambda and API Gateway configuration.
 #
@@ -24,4 +24,10 @@ variable "resource" {
   description = "API Gateway resource path (e.g., process)"
   type        = string
   default     = "process"
+}
+
+variable "app_name" {
+  description = "Application name used for resource naming"
+  type        = string
+  default     = "customer-domain"
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+# App: AWS Customer CRUD
+# Package: project_root
+# File: setup.sh
+# Version: 0.0.10
+# Author: Bobwares
+# Date: Fri Jun 06 16:06:00 UTC 2025
+# Description: Setup script to install Terraform and Python dependencies.
+#
+
+set -euo pipefail
+
+TERRAFORM_VERSION="1.7.5"
+
+if ! command -v terraform >/dev/null 2>&1; then
+    echo "Installing Terraform ${TERRAFORM_VERSION}"
+    curl -sL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o terraform.zip
+    unzip terraform.zip
+    mv terraform /usr/local/bin/
+    rm terraform.zip
+fi
+
+pip install -r requirements.txt

--- a/version.md
+++ b/version.md
@@ -38,3 +38,11 @@
 - Added Makefile with build/test/deploy commands
 - Documented dependencies in requirements.txt
 - Bumped project version to 0.0.8
+
+## 0.0.9 - Fri Jun 06 15:56:35 UTC 2025
+- Added app_name variable to Terraform for resource naming
+
+## 0.0.10 - Fri Jun 06 16:06:00 UTC 2025
+- Added setup.sh script to install Terraform and dependencies
+- Created codex.yaml to run setup script on workspace creation
+- Updated README with setup instructions


### PR DESCRIPTION
## Summary
- create `setup.sh` to install Terraform and Python requirements
- add `codex.yaml` so Codex runs `setup.sh` on workspace creation
- document setup script in README
- record changes in `version.md`

## Testing
- `pip install -r requirements.txt`
- `make test`
- `./setup.sh`
- `terraform -version`
- `make plan` *(fails: Error accessing remote module registry)*

------
https://chatgpt.com/codex/tasks/task_e_68430f445738832d86b9b41063cbfc24