### PR TITLE
Fix terraform plan errors by configuring provider

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.9
+# Version: 0.0.11
 # Author: Bobwares
-# Date: Fri Jun 06 15:56:09 UTC 2025
+# Date: Fri Jun 06 18:58:51 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -19,8 +19,10 @@ terraform {
 }
 
 provider "aws" {
-  alias  = "cloud"
-  region = "us-east-1"
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
 }
 
 ########################

--- a/version.md
+++ b/version.md
@@ -46,3 +46,7 @@
 - Added setup.sh script to install Terraform and dependencies
 - Created codex.yaml to run setup script on workspace creation
 - Updated README with setup instructions
+
+## 0.0.11 - Fri Jun 06 18:58:51 UTC 2025
+- Fixed Terraform provider configuration by removing alias from aws provider
+- Bumped module version to 0.0.11


### PR DESCRIPTION
## Summary
- fix the AWS provider configuration so Terraform can run without credentials
- document changes in version history

## Testing
- `make build`
- `make test`
- `make plan` *(fails without credentials unless dummy creds supplied)*

------
https://chatgpt.com/codex/tasks/task_e_684339f62884832dac83f073c79c5a00