### PR TITLE
Fix terraform naming collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: Makefile
-# Version: 0.0.8
+# Version: 0.0.9
 # Author: Bobwares
-# Date: Fri Jun 06 02:53:56 UTC 2025
+# Date: Fri Jun 06 21:00:00 UTC 2025
 # Description: Convenience targets for build, test, and deployment.
 #
 
@@ -16,7 +16,7 @@ test:
 	pytest -q
 
 plan:
-	cd iac && terraform init && terraform plan
+	cd iac && terraform init -upgrade && terraform plan
 
 deploy:
-	cd iac && terraform apply -auto-approve
+	cd iac && terraform init -upgrade && terraform apply -auto-approve

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.11
+# Version: 0.0.12
 # Author: Bobwares
-# Date: Fri Jun 06 18:58:51 UTC 2025
+# Date: Fri Jun 06 21:00:00 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -15,6 +15,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "= 5.99.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
   }
 }
 
@@ -25,6 +29,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+}
+
 ########################
 # Lambda Function (Registry Module)
 ########################
@@ -32,17 +41,17 @@ module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "7.20.2"
 
-  function_name = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}"
+  function_name = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}-${random_string.suffix.result}"
   handler       = "app.lambda_handler"
   runtime       = "python3.11"
   source_path   = "../src"
   publish       = true
 
   environment_variables = {
-    LOG_GROUP_NAME = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}"
+    LOG_GROUP_NAME = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}-${random_string.suffix.result}"
   }
 
-  logging_log_group             = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}"
+  logging_log_group             = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}-${random_string.suffix.result}"
   logging_log_format            = "JSON"
   logging_system_log_level      = "INFO"
   logging_application_log_level = "INFO"
@@ -59,7 +68,7 @@ module "http_api" {
   source  = "terraform-aws-modules/apigateway-v2/aws"
   version = "5.2.1"
 
-  name          = "${var.app_name}-${var.env}-api-${var.function_name}"
+  name          = "${var.app_name}-${var.env}-api-${var.function_name}-${random_string.suffix.result}"
   description   = "HTTP API for ${var.function_name}"
   protocol_type = "HTTP"
   disable_execute_api_endpoint = false

--- a/version.md
+++ b/version.md
@@ -50,3 +50,7 @@
 ## 0.0.11 - Fri Jun 06 18:58:51 UTC 2025
 - Fixed Terraform provider configuration by removing alias from aws provider
 - Bumped module version to 0.0.11
+
+## 0.0.12 - Fri Jun 06 21:00:00 UTC 2025
+- Added random suffix to Terraform resource names to avoid name collisions during deployment
+- Updated provider configuration to include random provider


### PR DESCRIPTION
## Summary
- add random provider and resource for unique names
- run `terraform init -upgrade` during make deploy
- document version history

## Testing
- `pytest -q`
- `make deploy` *(fails: Invalid integration URI specified)*

------
https://chatgpt.com/codex/tasks/task_e_684357eea168832db223fb1a9f6864e8