### PR TITLE
Fix HTTP API Lambda integration

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.12
+# Version: 0.0.13
 # Author: Bobwares
-# Date: Fri Jun 06 21:00:00 UTC 2025
+# Date: Fri Jun 06 21:23:54 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -83,7 +83,8 @@ module "http_api" {
   routes = {
     "ANY /${var.resource}" = {
       integration = {
-        lambda_arn = module.lambda.lambda_function_arn
+        uri                    = module.lambda.lambda_function_arn
+        payload_format_version = "2.0"
       }
     }
   }

--- a/version.md
+++ b/version.md
@@ -54,3 +54,7 @@
 ## 0.0.12 - Fri Jun 06 21:00:00 UTC 2025
 - Added random suffix to Terraform resource names to avoid name collisions during deployment
 - Updated provider configuration to include random provider
+
+## 0.0.13 - Fri Jun 06 21:23:54 UTC 2025
+- Fixed HTTP API integration URI configuration
+- Added payload format version for Lambda integration


### PR DESCRIPTION
## Summary
- fix http API integration by using `uri` property for Lambda
- bump infra version
- record changes in `version.md`

## Testing
- `pytest -q`
- `terraform init -upgrade`
- `terraform validate`
- `terraform plan -lock=false`


------
https://chatgpt.com/codex/tasks/task_e_68435bf82b3c832dbe92c4fd36a0e94f