### PR TITLE
Remove bearer token auth

### DIFF
--- a/e2e/test_requests.http
+++ b/e2e/test_requests.http
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: e2e
 # File: test_requests.http
-# Version: 0.0.4
+# Version: 0.0.5
 # Author: Bobwares
-# Date: Thu Jun 05 20:20:35 UTC 2025
+# Date: Fri Jun 06 23:55:35 UTC 2025
 # Description: Example HTTP requests for integration testing.
 
 ### Create Customer
@@ -22,4 +22,3 @@ Content-Type: application/json
 
 ### Get Customer
 GET https://example.com/customers/55555555-5555-5555-5555-555555555555
-Authorization: Bearer <token>

--- a/src/app.py
+++ b/src/app.py
@@ -1,16 +1,16 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: app.py
-# Version: 0.0.4
+# Version: 0.0.5
 # Author: Bobwares
-# Date: Thu Jun 05 20:20:35 UTC 2025
+# Date: Fri Jun 06 23:55:35 UTC 2025
 # Description: AWS Lambda handler for CRUD operations on DynamoDB.
 
 import json
 import logging
 from typing import Any, Dict
 from .models import Customer
-from .utils import get_dynamodb_client, validate_jwt, validate_customer_schema
+from .utils import get_dynamodb_client, validate_customer_schema
 
 
 logger = logging.getLogger(__name__)
@@ -23,13 +23,6 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     http_method = event["httpMethod"]
     path = event["path"]
     logger.info("Received request %s %s", http_method, path)
-    token = event["headers"].get("Authorization", "").split(" ")[1]
-    if not validate_jwt(token):
-        logger.warning("JWT validation failed")
-        return {
-            "statusCode": 401,
-            "body": json.dumps({"message": "Unauthorized"})
-        }
     table = "CustomerDomain"
 
     if http_method == "POST" and path == "/customers":

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: utils.py
-# Version: 0.0.4
+# Version: 0.0.5
 # Author: Bobwares
-# Date: Thu Jun 05 20:20:35 UTC 2025
+# Date: Fri Jun 06 23:55:35 UTC 2025
 # Description: Utility functions for AWS interactions.
 
 import json
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 import boto3
-from jose import JWTError, jwt
 from jsonschema import Draft202012Validator
 
 
@@ -23,16 +22,6 @@ CUSTOMER_VALIDATOR = Draft202012Validator(CUSTOMER_SCHEMA)
 def get_dynamodb_client():
     """Initialize and return a DynamoDB client."""
     return boto3.client("dynamodb")
-
-
-def validate_jwt(token: str) -> bool:
-    """Validate the JWT token."""
-    try:
-        jwt.decode(token, "your-secret-key", algorithms=["HS256"])
-        return True
-    except JWTError:
-        return False
-
 
 def validate_customer_schema(data: Dict[str, Any]) -> None:
     """Validate customer payload against JSON schema."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_app.py
-# Version: 0.0.4
+# Version: 0.0.5
 # Author: Bobwares
-# Date: Thu Jun 05 20:20:35 UTC 2025
+# Date: Fri Jun 06 23:55:35 UTC 2025
 # Description: Unit tests for app module.
 
 import json
@@ -13,15 +13,13 @@ from src.app import lambda_handler
 
 @patch('src.app.logger')
 @patch('src.app.get_dynamodb_client')
-@patch('src.app.validate_jwt')
-def test_lambda_handler_create_customer(mock_validate_jwt, mock_get_dynamodb_client, mock_logger):
+def test_lambda_handler_create_customer(mock_get_dynamodb_client, mock_logger):
     """Test creating a customer."""
-    mock_validate_jwt.return_value = True
     mock_client = mock_get_dynamodb_client.return_value
     event = {
         'httpMethod': 'POST',
         'path': '/customers',
-        'headers': {'Authorization': 'Bearer validtoken'},
+        'headers': {},
         'body': json.dumps({
             'customerId': '33333333-3333-3333-3333-333333333333',
             'name': {'first': 'Item1', 'last': 'Test'},
@@ -40,16 +38,14 @@ def test_lambda_handler_create_customer(mock_validate_jwt, mock_get_dynamodb_cli
 
 
 @patch('src.app.get_dynamodb_client')
-@patch('src.app.validate_jwt')
-def test_lambda_handler_get_customer_not_found(mock_validate_jwt, mock_get_dynamodb_client):
+def test_lambda_handler_get_customer_not_found(mock_get_dynamodb_client):
     """Test retrieving a non-existent customer."""
-    mock_validate_jwt.return_value = True
     mock_client = mock_get_dynamodb_client.return_value
     mock_client.get_item.return_value = {}
     event = {
         'httpMethod': 'GET',
         'path': '/customers/999',
-        'headers': {'Authorization': 'Bearer validtoken'},
+        'headers': {},
         'body': None
     }
     response = lambda_handler(event, None)

--- a/version.md
+++ b/version.md
@@ -66,3 +66,6 @@
 ## 0.0.15 - Fri Jun 06 22:25:53 UTC 2025
 - Updated step_functions.tf to use module lambda output
 - Bumped module version to 0.0.15
+
+## 0.0.16 - Fri Jun 06 23:55:35 UTC 2025
+- Removed JWT token authorization from Lambda handler and tests


### PR DESCRIPTION
## Summary
- drop JWT validation in Lambda handler
- remove auth header from tests and integration example

## Testing
- `pip install -r requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68437fb02dc8832d83bb72aca6407662