### PR TITLE
Add venv Makefile target and IntelliJ config

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2"
+             languageLevel="PYTHON311"
+             project-jdk-name="Python 3.11 ($PROJECT_DIR$/venv)"
+             project-jdk-type="Python SDK" />
+</project>

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: Makefile
-# Version: 0.0.9
+# Version: 0.0.10
 # Author: Bobwares
-# Date: Fri Jun 06 21:00:00 UTC 2025
+# Date: Fri Jun 06 23:59:00 UTC 2025
 # Description: Convenience targets for build, test, and deployment.
 #
 
-.PHONY: build test plan deploy
+.PHONY: build test plan deploy venv
 
-build:
-	pip install -r requirements.txt
+venv:
+        python3 -m venv venv
+        ./venv/bin/pip install -r requirements.txt
+
+build: venv
 
 test:
 	pytest -q

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Run `setup.sh` to install Terraform and Python dependencies. The Codex project a
 
 The `Makefile` provides a few convenience targets:
 
-- `make build` – install Python dependencies
+- `make venv` – create a Python virtual environment and install dependencies
+- `make build` – install Python dependencies using the virtual environment
 - `make test` – run unit tests
 - `make plan` – execute `terraform plan` from the `iac` directory
 - `make deploy` – deploy infrastructure with Terraform

--- a/version.md
+++ b/version.md
@@ -69,3 +69,6 @@
 
 ## 0.0.16 - Fri Jun 06 23:55:35 UTC 2025
 - Removed JWT token authorization from Lambda handler and tests
+## 0.0.17 - Fri Jun 06 23:59:00 UTC 2025
+- Added venv target to Makefile and IntelliJ configuration for virtual environment
+- Documented new command in README


### PR DESCRIPTION
## Summary
- create `venv` target in Makefile and use it from `build`
- document new command in README
- add IntelliJ settings to use project virtualenv
- record version 0.0.17

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684383d48a68832d8b375c92c939e478