### PR TITLE
Add e2e test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: .gitignore
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Thu Jun 5 14:41:42 UTC 2025
+# Date: Sat Jun 07 01:05:45 UTC 2025
 # Description: Git ignore file.
 
 __pycache__/
 *.pyc
 .lambda_function_payload.zip
+venv/

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,29 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: Makefile
-# Version: 0.0.10
+# Version: 0.0.12
 # Author: Bobwares
-# Date: Fri Jun 06 23:59:00 UTC 2025
+# Date: Sat Jun 07 01:10:48 UTC 2025
 # Description: Convenience targets for build, test, and deployment.
 #
 
-.PHONY: build test plan deploy venv
+.PHONY: build test e2e plan deploy venv
 
 venv:
-        python3 -m venv venv
-        ./venv/bin/pip install -r requirements.txt
+	python3 -m venv venv
+	./venv/bin/pip install -r requirements.txt
+	./venv/bin/pip install pytest
 
 build: venv
 
 test:
-	pytest -q
+	./venv/bin/pytest -q
+
+e2e: venv
+	./venv/bin/python e2e/run_e2e.py
 
 plan:
 	cd iac && terraform init -upgrade && terraform plan
-
+	
 deploy:
 	cd iac && terraform init -upgrade && terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ The `Makefile` provides a few convenience targets:
 - `make venv` – create a Python virtual environment and install dependencies
 - `make build` – install Python dependencies using the virtual environment
 - `make test` – run unit tests
+- `make e2e` – run end-to-end HTTP tests
 - `make plan` – execute `terraform plan` from the `iac` directory
 - `make deploy` – deploy infrastructure with Terraform

--- a/e2e/run_e2e.py
+++ b/e2e/run_e2e.py
@@ -1,0 +1,37 @@
+# App: AWS Customer CRUD
+# Package: e2e
+# File: run_e2e.py
+# Version: 0.0.1
+# Author: Bobwares
+# Date: Sat Jun 07 01:10:31 UTC 2025
+# Description: Simple HTTP end-to-end tests using requests.
+
+import os
+import json
+import requests
+
+API_BASE = os.getenv('API_BASE', 'https://8z9creg24d.execute-api.us-east-1.amazonaws.com')
+
+
+def main() -> None:
+    payload = {
+        "customerId": "55555555-5555-5555-5555-555555555555",
+        "name": {"first": "Alice", "last": "Smith"},
+        "primaryEmail": "alice@example.com",
+        "phoneNumbers": [{"label": "mobile", "number": "+14155550005"}],
+        "createdAt": "2025-06-05T00:00:00Z",
+        "updatedAt": "2025-06-05T00:00:00Z",
+        "status": "ACTIVE",
+    }
+
+    resp = requests.post(f"{API_BASE}/customers", json=payload)
+    print('POST', resp.status_code, resp.text)
+    resp.raise_for_status()
+
+    resp = requests.get(f"{API_BASE}/customers/{payload['customerId']}")
+    print('GET', resp.status_code, resp.text)
+    resp.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: main.tf
-# Version: 0.0.14
+# Version: 0.0.15
 # Author: Bobwares
-# Date: Fri Jun 06 22:00:43 UTC 2025
+# Date: Sat Jun 07 01:05:00 UTC 2025
 # Description: Terraform configuration using Registry modules for Lambda and HTTP API Gateway quick create mode.
 #
 
@@ -61,7 +61,7 @@ module "lambda" {
   function_name = "${var.app_name}-${var.env}-APIGatewayEventHandler-${var.function_name}-${random_string.suffix.result}"
   handler       = "app.lambda_handler"
   runtime       = "python3.11"
-  source_path   = "../src"
+  source_path   = ["../src", "../schema"]
   publish       = true
 
   environment_variables = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: requirements.txt
-# Version: 0.0.8
+# Version: 0.0.9
 # Author: Bobwares
-# Date: Fri Jun  6 02:53:51 UTC 2025
+# Date: Sat Jun 07 01:10:48 UTC 2025
 # Description: Python dependencies for Lambda function.
 #
 
@@ -12,3 +12,4 @@ pydantic[email]>=1.10.2
 aws-lambda-powertools>=1.27.0
 python-jose>=3.3.0
 jsonschema>=4.18.0
+requests>=2.31.0

--- a/tests/test_main_tf.py
+++ b/tests/test_main_tf.py
@@ -1,0 +1,17 @@
+# App: AWS Customer CRUD
+# Package: tests
+# File: test_main_tf.py
+# Version: 0.0.1
+# Author: Bobwares
+# Date: Sat Jun 07 01:05:00 UTC 2025
+# Description: Ensure main.tf includes schema directory in Lambda source path.
+
+import os
+
+
+def test_lambda_source_includes_schema():
+    path = os.path.join('iac', 'main.tf')
+    with open(path) as f:
+        content = f.read()
+    assert '../schema' in content
+

--- a/version.md
+++ b/version.md
@@ -75,3 +75,11 @@
 
 ## 0.0.18 - Sat Jun 07 00:35:16 UTC 2025
 - Updated IntelliJ misc.xml for JDK 21 configuration
+
+## 0.0.19 - Sat Jun 07 01:05:00 UTC 2025
+- Include schema directory in Lambda deployment package
+- Added unit test for source path configuration
+
+## 0.0.20 - Sat Jun 07 01:10:48 UTC 2025
+- Added e2e test runner and Makefile target
+- Updated requirements with requests library


### PR DESCRIPTION
## Summary
- add Python script to execute HTTP end-to-end tests
- install pytest in the `venv` target
- add `e2e` target to Makefile
- document new command in README
- track dependency for `requests`

## Testing
- `make venv`
- `make test`
- `make e2e` *(fails: 500 Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68438f1c0518832d97d212ca3194fecc