### PR TITLE
Add hello world GET customers endpoint

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: src
 # File: app.py
-# Version: 0.0.5
+# Version: 0.0.6
 # Author: Bobwares
-# Date: Fri Jun 06 23:55:35 UTC 2025
+# Date: Sat Jun 07 01:26:19 UTC 2025
 # Description: AWS Lambda handler for CRUD operations on DynamoDB.
 
 import json
@@ -35,6 +35,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return {
             "statusCode": 201,
             "body": json.dumps({"message": "Customer created"})
+        }
+    if http_method == "GET" and path == "/customers":
+        logger.info("Returning hello world for get customers")
+        return {
+            "statusCode": 200,
+            "body": "hello world"
         }
     if http_method == "GET" and path.startswith("/customers/"):
         item_id = path.split("/")[-1]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_app.py
-# Version: 0.0.5
+# Version: 0.0.6
 # Author: Bobwares
-# Date: Fri Jun 06 23:55:35 UTC 2025
+# Date: Sat Jun 07 01:26:19 UTC 2025
 # Description: Unit tests for app module.
 
 import json
@@ -35,6 +35,20 @@ def test_lambda_handler_create_customer(mock_get_dynamodb_client, mock_logger):
     assert json.loads(response['body'])['message'] == 'Customer created'
     mock_client.put_item.assert_called_once()
     mock_logger.info.assert_any_call('Creating customer %s', '33333333-3333-3333-3333-333333333333')
+
+
+@patch('src.app.get_dynamodb_client')
+def test_lambda_handler_get_customers(mock_get_dynamodb_client):
+    """Test retrieving all customers returns hello world."""
+    event = {
+        'httpMethod': 'GET',
+        'path': '/customers',
+        'headers': {},
+        'body': None
+    }
+    response = lambda_handler(event, None)
+    assert response['statusCode'] == 200
+    assert response['body'] == 'hello world'
 
 
 @patch('src.app.get_dynamodb_client')

--- a/version.md
+++ b/version.md
@@ -83,3 +83,7 @@
 ## 0.0.20 - Sat Jun 07 01:10:48 UTC 2025
 - Added e2e test runner and Makefile target
 - Updated requirements with requests library
+
+## 0.0.21 - Sat Jun 07 01:26:56 UTC 2025
+- Added GET /customers endpoint returning hello world
+- Updated unit tests


### PR DESCRIPTION
## Summary
- implement GET /customers that returns 'hello world'
- update unit tests for new endpoint
- document new version

## Testing
- `make venv`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684394a4cc10832daa1d40b0f16c2ccf