### PR TITLE
Fix e2e path configuration

### DIFF
--- a/e2e/run_e2e.py
+++ b/e2e/run_e2e.py
@@ -1,20 +1,23 @@
 # App: AWS Customer CRUD
 # Package: e2e
 # File: run_e2e.py
-# Version: 0.0.2
+# Version: 0.0.4
 # Author: Bobwares
-# Date: Sat Jun 07 01:41:18 UTC 2025
-# Description: Simple HTTP test for hello world endpoint.
+# Date: Sat Jun 07 01:50:52 UTC 2025
+# Description: Simple HTTP test for hello world endpoint hitting /customers.
 #
 import os
 import requests
 
 API_BASE = os.getenv('API_BASE', 'https://8z9creg24d.execute-api.us-east-1.amazonaws.com')
+API_PATH = os.getenv('API_PATH', '/customers')
 
 
 def main() -> None:
-    resp = requests.get(f"{API_BASE}/")
-    print('GET', resp.status_code, resp.text)
+    url = f"{API_BASE.rstrip('/')}{API_PATH}"
+    print('Requesting', url)
+    resp = requests.get(url)
+    print('Response', resp.status_code, resp.text)
     resp.raise_for_status()
 
 

--- a/e2e/test_requests.http
+++ b/e2e/test_requests.http
@@ -1,10 +1,10 @@
 # App: AWS Customer CRUD
 # Package: e2e
 # File: test_requests.http
-# Version: 0.0.6
+# Version: 0.0.8
 # Author: Bobwares
-# Date: Sat Jun 07 01:41:18 UTC 2025
-# Description: Example HTTP request for hello world endpoint.
+# Date: Sat Jun 07 01:50:52 UTC 2025
+# Description: Example HTTP request for hello world endpoint at /customers.
 #
 ### Hello World
-GET https://example.com/
+GET https://example.com/customers

--- a/version.md
+++ b/version.md
@@ -91,3 +91,9 @@
 ## 0.0.22 - Sat Jun 07 01:41:18 UTC 2025
 - Simplified app to only return hello world for any request
 - Removed DynamoDB logic and updated tests and e2e scripts
+
+## 0.0.23 - Sat Jun 07 01:50:52 UTC 2025
+- Updated e2e tests to call /customers path
+
+## 0.0.24 - Sat Jun 07 02:00:33 UTC 2025
+- Added API_PATH option for e2e tests


### PR DESCRIPTION
## Summary
- add API_PATH environment option for e2e tests
- update HTTP test metadata
- note new version

## Testing
- `make test`
- `API_BASE=https://httpbin.org/anything make e2e`


------
https://chatgpt.com/codex/tasks/task_e_68439a8d2de8832da3508369158e7e43