### PR TITLE
Refactor Terraform HTTP API

### DIFF
--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: iac
 # File: outputs.tf
-# Version: 0.0.8
+# Version: 0.0.9
 # Author: Bobwares
-# Date: Fri Jun 06 22:00:53 UTC 2025
+# Date: Sat Jun 07 03:07:53 UTC 2025
 # Description: Outputs for Lambda and HTTP API resources.
 #
 
@@ -13,7 +13,7 @@ output "lambda_function_name" {
 }
 
 output "api_endpoint" {
-  value       = module.http_api.api_endpoint
+  value       = aws_apigatewayv2_api.http_api.api_endpoint
   description = "API Gateway endpoint URL"
 }
 

--- a/tests/test_main_tf.py
+++ b/tests/test_main_tf.py
@@ -1,9 +1,9 @@
 # App: AWS Customer CRUD
 # Package: tests
 # File: test_main_tf.py
-# Version: 0.0.1
+# Version: 0.0.2
 # Author: Bobwares
-# Date: Sat Jun 07 01:05:00 UTC 2025
+# Date: Sat Jun 07 03:08:02 UTC 2025
 # Description: Ensure main.tf includes schema directory in Lambda source path.
 
 import os
@@ -14,4 +14,12 @@ def test_lambda_source_includes_schema():
     with open(path) as f:
         content = f.read()
     assert '../schema' in content
+
+
+def test_api_gateway_not_module():
+    path = os.path.join('iac', 'main.tf')
+    with open(path) as f:
+        content = f.read()
+    assert 'module "http_api"' not in content
+    assert 'aws_apigatewayv2_api' in content
 

--- a/version.md
+++ b/version.md
@@ -97,3 +97,7 @@
 
 ## 0.0.24 - Sat Jun 07 02:00:33 UTC 2025
 - Added API_PATH option for e2e tests
+
+## 0.0.25 - Sat Jun 07 03:08:15 UTC 2025
+- Refactored Terraform to create HTTP API resources without using a module
+- Updated outputs and tests accordingly


### PR DESCRIPTION
## Summary
- refactor Terraform to build HTTP API without module
- update outputs
- test for new API gateway resources
- document changes in version history

## Testing
- `make test`
- `make e2e` *(fails: 500 Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_6843ac706410832d9f1d9c076be91da9