### PR TITLE
Update Makefile workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,26 @@
 # App: AWS Customer CRUD
 # Package: project_root
 # File: Makefile
-# Version: 0.0.12
+# Version: 0.0.13
 # Author: Bobwares
-# Date: Sat Jun 07 01:10:48 UTC 2025
+# Date: Sat Jun 07 22:35:00 UTC 2025
 # Description: Convenience targets for build, test, and deployment.
 #
 
-.PHONY: build test e2e plan deploy venv
+.PHONY: install run test e2e plan deploy
+install:
+        pip install -r requirements.txt
 
-venv:
-	python3 -m venv venv
-	./venv/bin/pip install -r requirements.txt
-	./venv/bin/pip install pytest
-
-build: venv
+run:
+        streamlit run src/app.py
 
 test:
-	./venv/bin/pytest -q
+        pytest -q
 
-e2e: venv
-	./venv/bin/python e2e/run_e2e.py
+build: install
+
+e2e:
+        python e2e/run_e2e.py
 
 plan:
 	cd iac && terraform init -upgrade && terraform plan

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ visibility.
 ## Development
 Run `setup.sh` to install Terraform and Python dependencies. The Codex project automatically executes this script when the workspace is created.
 
-The `Makefile` provides a few convenience targets:
+The `Makefile` provides a few convenience targets that run outside a virtual environment:
 
-- `make venv` – create a Python virtual environment and install dependencies
-- `make build` – install Python dependencies using the virtual environment
+- `make install` – install Python dependencies
+- `make run` – start the Streamlit application
 - `make test` – run unit tests
 - `make e2e` – run end-to-end HTTP tests
 - `make plan` – execute `terraform plan` from the `iac` directory

--- a/version.md
+++ b/version.md
@@ -101,3 +101,7 @@
 ## 0.0.25 - Sat Jun 07 03:08:15 UTC 2025
 - Refactored Terraform to create HTTP API resources without using a module
 - Updated outputs and tests accordingly
+
+## 0.0.26 - Sat Jun 07 22:35:23 UTC 2025
+- Updated Makefile to run install, run, and test tasks outside a virtual environment
+- Documented new targets in README


### PR DESCRIPTION
## Summary
- simplify Makefile to run commands without using a virtual environment
- document new Makefile targets in README
- record version history

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844be33c840832da467629f91e821a7